### PR TITLE
Fix axia link to new telos location

### DIFF
--- a/Reference/Livewire.md
+++ b/Reference/Livewire.md
@@ -31,7 +31,7 @@ If Livewire behaved like a standard (unicast) service, the network would quickly
 
 There are two types of livewire streams: standard streams incur a relatively high amount of a delay because of the nature of packeting - if we wait for a standard payload on a 1500 byte packet to fill, there's a certain amount of latency incurred. By contrast, Live streams keep the packet size very small to minimize latency, but this also increases network load so they should only be used on critical sources like microphones and airfeeds. CD players can easily get by with more latency so they should use standard streams.
 
-Livewire is the protcol that all Axia/Telos equipment uses. For more information see the WMFO Operations Mandatory Reading *Introduction to Livewire* and other [manuals](http://axiaaudio.com/manuals "http://axiaaudio.com/manuals") published by Axia.
+Livewire is the protcol that all Axia/Telos equipment uses. For more information see the WMFO Operations Mandatory Reading *Introduction to Livewire* and other [manuals](https://www.telosalliance.com/downloads?search=product-manuals#downloadListing "https://www.telosalliance.com/downloads?search=product-manuals#downloadListing") published by the Telos Alliance.
 
 ### Entering and Leaving the Livewire Network
 


### PR DESCRIPTION
I noticed the link was dead as all docs seem to have moved to telos.

This is some great documentation on Livewire! Exactly what I was looking for to explain a lot of this stuff to someone who has a large background in IT and some in analog audio but not so that much in AoIP.

Is [this](https://www.telosalliance.com/images/Axia%20Products/Support%20Documents/Tech%20Tips/Introduction%20to%20Livewire+%20-TA15%2019013-Web.pdf) the *Introduction to Livewire* the article mentions or are there others?

Thanks from [Radio Bern RaBe](http://rabe.ch) for documenting this in the open!

Cheers,
Lucas